### PR TITLE
Remove `ctransformers` submodule, add to requirements.txt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "ctransformers"]
-	path = ctransformers
-	url = https://github.com/abacaj/ctransformers
-	branch = replit-code

--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ First create a venv.
 ```sh
 python -m venv env && source env/bin/activate
 ```
-Next install the submodule with ctransformers patch.
-
-```sh
-git submodule update --init --recursive
-```
 
 Next install dependencies.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-./ctransformers
+ctransformers==0.2.11
 transformers==4.30.2


### PR DESCRIPTION
Now that your ctransformers patch (https://github.com/marella/ctransformers/pull/37) has been accepted and released in v0.2.11, it should be safe to remove the submodule and instead install ctransformers via `requirements.txt`.

Many thanks for putting together this replit inference example repo as well!